### PR TITLE
Get taxize from ropensci, not CRAN

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Imports:
   pander, 
   readxl,
   rlang,
-  taxize,
+  ropensci/taxize,
   testthat,
   writexl
 Suggests:


### PR DESCRIPTION
Simple pull request to check if we can get taxize directly form ropensci, thus removing the current installation problem, which stems from taxize not being on CRAN at this moment.